### PR TITLE
Add support for gettid() provided by glibc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,9 @@ if eval "test \"`echo '$ac_cv_func___nss_configure_lookup'`\" != yes"; then
    AC_CHECK_LIB(resolv, res_gethostbyname)
 fi
 
+dnl Check for gettid wrapper
+AC_CHECK_FUNC(gettid, [AC_DEFINE(HAVE_GETTID, 1, [Define to 1 if gettid() is available])])
+
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 

--- a/src/log_msg.c
+++ b/src/log_msg.c
@@ -26,6 +26,8 @@
 #include "log_msg.h"
 
 #include <sys/syscall.h>
+
+#ifndef HAVE_GETTID
 #ifdef __NR_gettid
 static pid_t
 gettid (void)
@@ -39,6 +41,7 @@ gettid (void)
     return getpid ();
 }
 #endif
+#endif /* ! HAVE_GETTID */
 
 int debug_flag = 0;
 int logfile_flag = 0;


### PR DESCRIPTION
Wrapper for gettid system call was not provided by glibc until version 2.30.
Since version 2.30 glibc provides it and it causes conflicts with
gettid() defined locally (in log_msg.c). Use the local definition of
gettid only if system gettid is not available.

https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=NEWS;hb=HEAD